### PR TITLE
ruby: manually manage packet_buffer lifetime

### DIFF
--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -106,6 +106,15 @@ typedef struct {
  */
 int trilogy_init(trilogy_conn_t *conn);
 
+/* trilogy_init_no_buffer - Same as trilogy_init but doesn't allocate the packet buffer
+ *
+ * conn - A pre-allocated trilogy_conn_t pointer.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The trilogy_conn_t pointer was properly initialized
+ */
+int trilogy_init_no_buffer(trilogy_conn_t *conn);
+
 /* trilogy_flush_writes - Attempt to flush the internal packet buffer to the
  * network. This must be used if a `_send` function returns TRILOGY_AGAIN, and
  * should continue to be called until it returns a value other than

--- a/inc/trilogy/error.h
+++ b/inc/trilogy/error.h
@@ -25,7 +25,8 @@
     XX(TRILOGY_MAX_PACKET_EXCEEDED, -20)                                                                               \
     XX(TRILOGY_UNKNOWN_TYPE, -21)                                                                                      \
     XX(TRILOGY_TIMEOUT, -22)                                                                                           \
-    XX(TRILOGY_AUTH_PLUGIN_ERROR, -23)
+    XX(TRILOGY_AUTH_PLUGIN_ERROR, -23)                                                                                 \
+    XX(TRILOGY_MEM_ERROR, -24)
 
 enum {
 #define XX(name, code) name = code,

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -23,6 +23,9 @@ int trilogy_buffer_expand(trilogy_buffer_t *buffer, size_t needed)
 {
     // expand buffer if necessary
     if (buffer->len + needed > buffer->cap) {
+        if (buffer->buff == NULL)
+            return TRILOGY_MEM_ERROR;
+
         size_t new_cap = buffer->cap;
 
         while (buffer->len + needed > new_cap) {
@@ -59,7 +62,9 @@ int trilogy_buffer_putc(trilogy_buffer_t *buffer, uint8_t c)
 
 void trilogy_buffer_free(trilogy_buffer_t *buffer)
 {
-    free(buffer->buff);
-    buffer->buff = NULL;
-    buffer->len = buffer->cap = 0;
+    if (buffer->buff) {
+        free(buffer->buff);
+        buffer->buff = NULL;
+        buffer->len = buffer->cap = 0;
+    }
 }

--- a/src/client.c
+++ b/src/client.c
@@ -117,10 +117,8 @@ static int begin_write(trilogy_conn_t *conn)
     return trilogy_flush_writes(conn);
 }
 
-int trilogy_init(trilogy_conn_t *conn)
+int trilogy_init_no_buffer(trilogy_conn_t *conn)
 {
-    int rc;
-
     conn->affected_rows = 0;
     conn->last_insert_id = 0;
     conn->warning_count = 0;
@@ -142,8 +140,14 @@ int trilogy_init(trilogy_conn_t *conn)
     trilogy_packet_parser_init(&conn->packet_parser, &packet_parser_callbacks);
     conn->packet_parser.user_data = &conn->packet_buffer;
 
-    CHECKED(trilogy_buffer_init(&conn->packet_buffer, TRILOGY_DEFAULT_BUF_SIZE));
+    return TRILOGY_OK;
+}
 
+int trilogy_init(trilogy_conn_t *conn)
+{
+    int rc;
+    trilogy_init_no_buffer(conn);
+    CHECKED(trilogy_buffer_init(&conn->packet_buffer, TRILOGY_DEFAULT_BUF_SIZE));
     return TRILOGY_OK;
 }
 


### PR DESCRIPTION
The trilogy client eagerly allocate a 32kiB buffer, and grows it as needed. It's never freed not shrunk until the connection is closed.

For basic usage it's not a big deal, but some applications may have dozens if not hundreds of connections that are mostly idle. A common case being multi-tenant applications with horizontal sharding. In such cases you only ever query one database but have open connections to many databases.

This situation might lead to a lot of memory retained by trilogy connections and never really released.

Ideally you'd want to use a buffer pool, but because we call `rb_ext_ractor_safe(true)`, we'd need such pool to be ractor safe, which means either being synchronized or having one pool per ractor.

This commit simply malloc and free the buffer directly to prove the approach works, and a pool could be fitted on top.

Before:

```ruby
>> t = Trilogy.new(database: "test")
>> ObjectSpace.memsize_of(t)
=> 66176
>> t.query("select '#{"a" * 10_000_000}' as a"); nil
>> ObjectSpace.memsize_of(t)
=> 16810624
```

After:

```ruby
>> t = Trilogy.new(database: "test")
>> ObjectSpace.memsize_of(t)
=> 33408
>>  t.query("select '#{"a" * 10_000_000}' as a"); nil
>> ObjectSpace.memsize_of(t)
=> 33408
```

@tenderlove @jhawthorn @matthewd do you think it'd be worth implementing a buffer pool?

Also, annoyingly, each client is still 33kiB large because there's another fixed size 32kiB buffer for reading, it could probably receive a similar treatment.